### PR TITLE
fix: retry when mergeable_state is UNKNOWN

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -34493,17 +34493,37 @@ git push --force-with-lease
     }
 }
 /**
- * Get the merge state of a PR.
+ * Get the merge state of a PR, retrying when UNKNOWN.
+ *
+ * GitHub computes mergeable_state asynchronously. When the action triggers
+ * immediately after a merge to main, the state may be UNKNOWN for several
+ * seconds. We retry with exponential backoff to avoid skipping PRs that
+ * are actually BEHIND.
+ *
+ * @see https://docs.github.com/en/rest/pulls/pulls#get-a-pull-request
  */
 async function getMergeState(octokit, owner, repo, prNumber) {
-    const { data } = await octokit.rest.pulls.get({
-        owner,
-        repo,
-        pull_number: prNumber,
-    });
-    // GitHub returns mergeable_state but we need mergeStateStatus equivalent
-    // mergeable_state values: "behind", "clean", "dirty", "blocked", "unknown", "unstable", "has_hooks"
-    return (data.mergeable_state?.toUpperCase() ?? "UNKNOWN");
+    const maxRetries = 3;
+    const baseDelayMs = 3000;
+    for (let attempt = 0; attempt <= maxRetries; attempt++) {
+        const { data } = await octokit.rest.pulls.get({
+            owner,
+            repo,
+            pull_number: prNumber,
+        });
+        // mergeable_state values: "behind", "clean", "dirty", "blocked", "unknown", "unstable", "has_hooks"
+        const state = (data.mergeable_state?.toUpperCase() ?? "UNKNOWN");
+        if (state !== "UNKNOWN" || attempt === maxRetries) {
+            if (state === "UNKNOWN" && attempt === maxRetries) {
+                core.warning(`PR #${prNumber}: mergeable_state still UNKNOWN after ${maxRetries} retries`);
+            }
+            return state;
+        }
+        const delayMs = baseDelayMs * Math.pow(2, attempt);
+        core.info(`PR #${prNumber}: mergeable_state is UNKNOWN, retrying in ${delayMs / 1000}s (attempt ${attempt + 1}/${maxRetries})...`);
+        await new Promise((resolve) => setTimeout(resolve, delayMs));
+    }
+    return "UNKNOWN";
 }
 /**
  * Update a single PR branch by merging the base branch into it.

--- a/src/update-branches.ts
+++ b/src/update-branches.ts
@@ -112,7 +112,14 @@ git push --force-with-lease
 }
 
 /**
- * Get the merge state of a PR.
+ * Get the merge state of a PR, retrying when UNKNOWN.
+ *
+ * GitHub computes mergeable_state asynchronously. When the action triggers
+ * immediately after a merge to main, the state may be UNKNOWN for several
+ * seconds. We retry with exponential backoff to avoid skipping PRs that
+ * are actually BEHIND.
+ *
+ * @see https://docs.github.com/en/rest/pulls/pulls#get-a-pull-request
  */
 async function getMergeState(
   octokit: Octokit,
@@ -120,15 +127,32 @@ async function getMergeState(
   repo: string,
   prNumber: number
 ): Promise<MergeState> {
-  const { data } = await octokit.rest.pulls.get({
-    owner,
-    repo,
-    pull_number: prNumber,
-  });
+  const maxRetries = 3;
+  const baseDelayMs = 3000;
 
-  // GitHub returns mergeable_state but we need mergeStateStatus equivalent
-  // mergeable_state values: "behind", "clean", "dirty", "blocked", "unknown", "unstable", "has_hooks"
-  return (data.mergeable_state?.toUpperCase() ?? "UNKNOWN") as MergeState;
+  for (let attempt = 0; attempt <= maxRetries; attempt++) {
+    const { data } = await octokit.rest.pulls.get({
+      owner,
+      repo,
+      pull_number: prNumber,
+    });
+
+    // mergeable_state values: "behind", "clean", "dirty", "blocked", "unknown", "unstable", "has_hooks"
+    const state = (data.mergeable_state?.toUpperCase() ?? "UNKNOWN") as MergeState;
+
+    if (state !== "UNKNOWN" || attempt === maxRetries) {
+      if (state === "UNKNOWN" && attempt === maxRetries) {
+        core.warning(`PR #${prNumber}: mergeable_state still UNKNOWN after ${maxRetries} retries`);
+      }
+      return state;
+    }
+
+    const delayMs = baseDelayMs * Math.pow(2, attempt);
+    core.info(`PR #${prNumber}: mergeable_state is UNKNOWN, retrying in ${delayMs / 1000}s (attempt ${attempt + 1}/${maxRetries})...`);
+    await new Promise((resolve) => setTimeout(resolve, delayMs));
+  }
+
+  return "UNKNOWN";
 }
 
 /**

--- a/tests/update-branches.test.ts
+++ b/tests/update-branches.test.ts
@@ -15,7 +15,7 @@ vi.mock("@actions/core", () => ({
 }));
 
 // Import after mocks
-import { writeSummary } from "../src/update-branches";
+import { updateBranches, writeSummary } from "../src/update-branches";
 import * as core from "@actions/core";
 
 const defaultInputs: ActionInputs = {
@@ -121,5 +121,108 @@ describe("writeSummary", () => {
 
     const addRawCall = vi.mocked(core.summary.addRaw).mock.calls[0][0];
     expect(addRawCall).not.toContain("Priority Order");
+  });
+});
+
+describe("updateBranches", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+  });
+
+  const makeOctokit = (getMergeStates: string[], updateResult = "updated") => {
+    let pullsGetCalls = 0;
+    return {
+      rest: {
+        pulls: {
+          get: vi.fn().mockImplementation(() => {
+            const state = getMergeStates[pullsGetCalls] ?? getMergeStates[getMergeStates.length - 1];
+            pullsGetCalls++;
+            return Promise.resolve({ data: { mergeable_state: state } });
+          }),
+          updateBranch: vi.fn().mockResolvedValue({}),
+        },
+        issues: {
+          addLabels: vi.fn().mockResolvedValue({}),
+          createComment: vi.fn().mockResolvedValue({}),
+        },
+        actions: {
+          listWorkflowRuns: vi.fn().mockResolvedValue({ data: { workflow_runs: [] } }),
+          listWorkflowRunsForRepo: vi.fn().mockResolvedValue({ data: { workflow_runs: [] } }),
+          cancelWorkflowRun: vi.fn().mockResolvedValue({}),
+        },
+      },
+    } as any;
+  };
+
+  it("skips PR when merge state is CLEAN", async () => {
+    const octokit = makeOctokit(["clean"]);
+    const prs = [makePrioritizedPR(1, 0)];
+
+    const result = await updateBranches(octokit, "owner", "repo", prs, defaultInputs);
+
+    expect(result.skipped).toBe(1);
+    expect(result.updated).toBe(0);
+    expect(octokit.rest.pulls.get).toHaveBeenCalledTimes(1);
+  });
+
+  it("updates PR when merge state is BEHIND", async () => {
+    const octokit = makeOctokit(["behind"]);
+    const prs = [makePrioritizedPR(1, 0)];
+
+    const result = await updateBranches(octokit, "owner", "repo", prs, defaultInputs);
+
+    expect(result.updated).toBe(1);
+    expect(result.skipped).toBe(0);
+    expect(octokit.rest.pulls.updateBranch).toHaveBeenCalledTimes(1);
+  });
+
+  it("retries when merge state is UNKNOWN then resolves to BEHIND", async () => {
+    const octokit = makeOctokit(["unknown", "behind"]);
+    const prs = [makePrioritizedPR(1, 0)];
+
+    const promise = updateBranches(octokit, "owner", "repo", prs, defaultInputs);
+    // Advance past the retry delay
+    await vi.advanceTimersByTimeAsync(5000);
+
+    const result = await promise;
+
+    expect(result.updated).toBe(1);
+    expect(octokit.rest.pulls.get).toHaveBeenCalledTimes(2);
+    expect(core.info).toHaveBeenCalledWith(
+      expect.stringContaining("UNKNOWN, retrying")
+    );
+  });
+
+  it("retries multiple times when merge state stays UNKNOWN", async () => {
+    const octokit = makeOctokit(["unknown", "unknown", "unknown", "behind"]);
+    const prs = [makePrioritizedPR(1, 0)];
+
+    const promise = updateBranches(octokit, "owner", "repo", prs, defaultInputs);
+    // Advance past all retry delays (3s + 6s + 12s)
+    await vi.advanceTimersByTimeAsync(25000);
+
+    const result = await promise;
+
+    expect(result.updated).toBe(1);
+    expect(octokit.rest.pulls.get).toHaveBeenCalledTimes(4);
+  });
+
+  it("gives up after max retries and skips PR", async () => {
+    // All 4 calls return unknown (1 initial + 3 retries)
+    const octokit = makeOctokit(["unknown", "unknown", "unknown", "unknown"]);
+    const prs = [makePrioritizedPR(1, 0)];
+
+    const promise = updateBranches(octokit, "owner", "repo", prs, defaultInputs);
+    await vi.advanceTimersByTimeAsync(30000);
+
+    const result = await promise;
+
+    expect(result.skipped).toBe(1);
+    expect(result.updated).toBe(0);
+    expect(octokit.rest.pulls.get).toHaveBeenCalledTimes(4);
+    expect(core.warning).toHaveBeenCalledWith(
+      expect.stringContaining("still UNKNOWN after 3 retries")
+    );
   });
 });


### PR DESCRIPTION
## Summary

Fixes #3 — race condition where `mergeable_state` is `UNKNOWN` when the action triggers immediately after a merge to main (within 2 seconds).

- Adds retry with exponential backoff (3s, 6s, 12s) in `getMergeState()` when state is `UNKNOWN`
- After 3 retries, warns and treats as `UNKNOWN` (skips the PR)
- Adds 5 test cases covering retry scenarios

## Test plan

- [x] `npm run lint` passes
- [x] `npm test` passes (42 tests, including 5 new)
- [x] `npm run build` produces dist bundle