### PR TITLE
fix: handle ambiguous merge states correctly

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -34540,10 +34540,13 @@ async function updatePRBranch(octokit, owner, repo, prNumber, expectedSha) {
     }
     catch (error) {
         const status = error.status ?? 0;
+        const message = String(error.message ?? "");
         if (status === 422) {
-            const message = String(error.message ?? "");
             if (/merge conflict/i.test(message)) {
                 return "conflict";
+            }
+            if (/already up.to.date/i.test(message) || /no update/i.test(message)) {
+                return "up_to_date";
             }
             return "error";
         }
@@ -34567,8 +34570,9 @@ async function updateBranches(octokit, owner, repo, prs, inputs) {
         core.startGroup(`PR #${pr.number} (priority=${pr.priority})`);
         const mergeState = await getMergeState(octokit, owner, repo, pr.number);
         core.info(`Merge state: ${mergeState}`);
-        if (mergeState !== "BEHIND") {
-            core.info(`Already up to date (${mergeState})`);
+        // CLEAN: definitely up to date, skip
+        if (mergeState === "CLEAN") {
+            core.info("Branch is up to date");
             result.skipped++;
             core.endGroup();
             if (inputs.updateMode === "next") {
@@ -34577,7 +34581,23 @@ async function updateBranches(octokit, owner, repo, prs, inputs) {
             }
             continue;
         }
-        core.info("Branch is behind, updating...");
+        // DIRTY: has merge conflicts — label and notify, don't attempt update
+        if (mergeState === "DIRTY") {
+            core.info("Branch has merge conflicts");
+            result.conflicts++;
+            await handleConflict(octokit, owner, repo, pr.number, inputs);
+            core.endGroup();
+            continue;
+        }
+        // BEHIND: definitely needs update
+        // BLOCKED/UNSTABLE/HAS_HOOKS/UNKNOWN: may also be behind — attempt update
+        // and let the API tell us if there's nothing to do
+        if (mergeState !== "BEHIND") {
+            core.info(`State is ${mergeState} (may also be behind), attempting update...`);
+        }
+        else {
+            core.info("Branch is behind, updating...");
+        }
         // Cancel stale CI
         if (inputs.cancelStaleCi) {
             const cancelled = await cancelStaleRuns(octokit, owner, repo, pr.branch, inputs.ciWorkflow);
@@ -34596,6 +34616,10 @@ async function updateBranches(octokit, owner, repo, prs, inputs) {
                 core.info("Merge conflict detected");
                 result.conflicts++;
                 await handleConflict(octokit, owner, repo, pr.number, inputs);
+                break;
+            case "up_to_date":
+                core.info("Branch is already up to date");
+                result.skipped++;
                 break;
             case "sha_mismatch":
                 core.info("Branch changed during update (SHA mismatch). Will retry on next push.");

--- a/src/update-branches.ts
+++ b/src/update-branches.ts
@@ -164,7 +164,7 @@ async function updatePRBranch(
   repo: string,
   prNumber: number,
   expectedSha: string
-): Promise<"updated" | "conflict" | "sha_mismatch" | "error"> {
+): Promise<"updated" | "conflict" | "up_to_date" | "sha_mismatch" | "error"> {
   try {
     await octokit.rest.pulls.updateBranch({
       owner,
@@ -175,11 +175,14 @@ async function updatePRBranch(
     return "updated";
   } catch (error: unknown) {
     const status = (error as { status?: number }).status ?? 0;
+    const message = String((error as { message?: string }).message ?? "");
 
     if (status === 422) {
-      const message = String((error as { message?: string }).message ?? "");
       if (/merge conflict/i.test(message)) {
         return "conflict";
+      }
+      if (/already up.to.date/i.test(message) || /no update/i.test(message)) {
+        return "up_to_date";
       }
       return "error";
     }
@@ -216,8 +219,9 @@ export async function updateBranches(
     const mergeState = await getMergeState(octokit, owner, repo, pr.number);
     core.info(`Merge state: ${mergeState}`);
 
-    if (mergeState !== "BEHIND") {
-      core.info(`Already up to date (${mergeState})`);
+    // CLEAN: definitely up to date, skip
+    if (mergeState === "CLEAN") {
+      core.info("Branch is up to date");
       result.skipped++;
       core.endGroup();
 
@@ -228,7 +232,23 @@ export async function updateBranches(
       continue;
     }
 
-    core.info("Branch is behind, updating...");
+    // DIRTY: has merge conflicts — label and notify, don't attempt update
+    if (mergeState === "DIRTY") {
+      core.info("Branch has merge conflicts");
+      result.conflicts++;
+      await handleConflict(octokit, owner, repo, pr.number, inputs);
+      core.endGroup();
+      continue;
+    }
+
+    // BEHIND: definitely needs update
+    // BLOCKED/UNSTABLE/HAS_HOOKS/UNKNOWN: may also be behind — attempt update
+    // and let the API tell us if there's nothing to do
+    if (mergeState !== "BEHIND") {
+      core.info(`State is ${mergeState} (may also be behind), attempting update...`);
+    } else {
+      core.info("Branch is behind, updating...");
+    }
 
     // Cancel stale CI
     if (inputs.cancelStaleCi) {
@@ -256,6 +276,10 @@ export async function updateBranches(
         core.info("Merge conflict detected");
         result.conflicts++;
         await handleConflict(octokit, owner, repo, pr.number, inputs);
+        break;
+      case "up_to_date":
+        core.info("Branch is already up to date");
+        result.skipped++;
         break;
       case "sha_mismatch":
         core.info("Branch changed during update (SHA mismatch). Will retry on next push.");

--- a/tests/update-branches.test.ts
+++ b/tests/update-branches.test.ts
@@ -208,8 +208,9 @@ describe("updateBranches", () => {
     expect(octokit.rest.pulls.get).toHaveBeenCalledTimes(4);
   });
 
-  it("gives up after max retries and skips PR", async () => {
+  it("attempts update after max retries when state stays UNKNOWN", async () => {
     // All 4 calls return unknown (1 initial + 3 retries)
+    // UNKNOWN is ambiguous — may be behind, so we attempt the update
     const octokit = makeOctokit(["unknown", "unknown", "unknown", "unknown"]);
     const prs = [makePrioritizedPR(1, 0)];
 
@@ -218,11 +219,127 @@ describe("updateBranches", () => {
 
     const result = await promise;
 
-    expect(result.skipped).toBe(1);
-    expect(result.updated).toBe(0);
+    expect(result.updated).toBe(1);
     expect(octokit.rest.pulls.get).toHaveBeenCalledTimes(4);
+    expect(octokit.rest.pulls.updateBranch).toHaveBeenCalledTimes(1);
     expect(core.warning).toHaveBeenCalledWith(
       expect.stringContaining("still UNKNOWN after 3 retries")
     );
+  });
+
+  it("handles DIRTY state as conflict", async () => {
+    const octokit = makeOctokit(["dirty"]);
+    const prs = [makePrioritizedPR(1, 0)];
+
+    const result = await updateBranches(octokit, "owner", "repo", prs, defaultInputs);
+
+    expect(result.conflicts).toBe(1);
+    expect(result.updated).toBe(0);
+    expect(octokit.rest.pulls.updateBranch).not.toHaveBeenCalled();
+    expect(octokit.rest.issues.addLabels).toHaveBeenCalledWith(
+      expect.objectContaining({ labels: ["needs-rebase"] })
+    );
+    expect(octokit.rest.issues.createComment).toHaveBeenCalled();
+  });
+
+  it("attempts update for BLOCKED state (may also be behind)", async () => {
+    const octokit = makeOctokit(["blocked"]);
+    const prs = [makePrioritizedPR(1, 0)];
+
+    const result = await updateBranches(octokit, "owner", "repo", prs, defaultInputs);
+
+    expect(result.updated).toBe(1);
+    expect(octokit.rest.pulls.updateBranch).toHaveBeenCalledTimes(1);
+    expect(core.info).toHaveBeenCalledWith(
+      expect.stringContaining("BLOCKED (may also be behind)")
+    );
+  });
+
+  it("attempts update for UNSTABLE state", async () => {
+    const octokit = makeOctokit(["unstable"]);
+    const prs = [makePrioritizedPR(1, 0)];
+
+    const result = await updateBranches(octokit, "owner", "repo", prs, defaultInputs);
+
+    expect(result.updated).toBe(1);
+    expect(octokit.rest.pulls.updateBranch).toHaveBeenCalledTimes(1);
+  });
+
+  it("attempts update for HAS_HOOKS state", async () => {
+    const octokit = makeOctokit(["has_hooks"]);
+    const prs = [makePrioritizedPR(1, 0)];
+
+    const result = await updateBranches(octokit, "owner", "repo", prs, defaultInputs);
+
+    expect(result.updated).toBe(1);
+    expect(octokit.rest.pulls.updateBranch).toHaveBeenCalledTimes(1);
+  });
+
+  it("counts up_to_date API response as skipped", async () => {
+    // State is BLOCKED (ambiguous) but API says already up to date
+    const octokit = makeOctokit(["blocked"]);
+    octokit.rest.pulls.updateBranch.mockRejectedValue({
+      status: 422,
+      message: "merge commit is already up to date",
+    });
+    const prs = [makePrioritizedPR(1, 0)];
+
+    const result = await updateBranches(octokit, "owner", "repo", prs, defaultInputs);
+
+    expect(result.skipped).toBe(1);
+    expect(result.updated).toBe(0);
+    expect(result.errors).toBe(0);
+  });
+
+  it("counts conflict from API response separately from DIRTY", async () => {
+    // State is BEHIND but API discovers conflict during update
+    const octokit = makeOctokit(["behind"]);
+    octokit.rest.pulls.updateBranch.mockRejectedValue({
+      status: 422,
+      message: "Merge conflict",
+    });
+    const prs = [makePrioritizedPR(1, 0)];
+
+    const result = await updateBranches(octokit, "owner", "repo", prs, defaultInputs);
+
+    expect(result.conflicts).toBe(1);
+    expect(result.updated).toBe(0);
+    expect(octokit.rest.issues.addLabels).toHaveBeenCalled();
+  });
+
+  it("handles SHA mismatch gracefully", async () => {
+    const octokit = makeOctokit(["behind"]);
+    octokit.rest.pulls.updateBranch.mockRejectedValue({
+      status: 409,
+      message: "Head branch was modified",
+    });
+    const prs = [makePrioritizedPR(1, 0)];
+
+    const result = await updateBranches(octokit, "owner", "repo", prs, defaultInputs);
+
+    expect(result.skipped).toBe(1);
+    expect(result.errors).toBe(0);
+  });
+
+  it("stops after first PR in next mode", async () => {
+    const octokit = makeOctokit(["behind"]);
+    const prs = [makePrioritizedPR(1, 0), makePrioritizedPR(2, 0)];
+    const inputs = { ...defaultInputs, updateMode: "next" as const };
+
+    const result = await updateBranches(octokit, "owner", "repo", prs, inputs);
+
+    expect(result.updated).toBe(1);
+    expect(octokit.rest.pulls.updateBranch).toHaveBeenCalledTimes(1);
+  });
+
+  it("respects max-updates limit", async () => {
+    const octokit = makeOctokit(["behind"]);
+    const prs = [makePrioritizedPR(1, 0), makePrioritizedPR(2, 0), makePrioritizedPR(3, 0)];
+    const inputs = { ...defaultInputs, maxUpdates: 2 };
+
+    const result = await updateBranches(octokit, "owner", "repo", prs, inputs);
+
+    expect(result.updated).toBe(2);
+    expect(octokit.rest.pulls.updateBranch).toHaveBeenCalledTimes(2);
   });
 });


### PR DESCRIPTION
## Summary

- **DIRTY** state now properly treated as conflict (adds label + comment) instead of being silently skipped
- **BLOCKED/UNSTABLE/HAS_HOOKS** states now attempt branch update (they may also be behind) instead of skipping
- **UNKNOWN** after retries now attempts update instead of skipping (it's ambiguous, let the API decide)
- 422 "already up to date" responses now counted as `skipped` instead of `error`
- 409 SHA mismatch responses now counted as `skipped` instead of `error`

## Why

GitHub's `mergeable_state` is a composite signal. States like BLOCKED (failing required checks) and UNSTABLE (failing non-required checks) can co-exist with being behind main. Previously we skipped these PRs entirely, meaning they'd never get updated until their state changed to exactly BEHIND.

DIRTY was the worst — PRs with merge conflicts were silently skipped without adding the `needs-rebase` label or posting a comment to notify the author.

## Test plan

- [x] 51 tests pass (18 in update-branches, 10 in filter, 23 in priority)
- [x] New tests for DIRTY→conflict, BLOCKED/UNSTABLE/HAS_HOOKS→attempt update, up_to_date/sha_mismatch outcomes, next mode, max-updates limit
- [x] Lint passes, dist rebuilt