### PR TITLE
feat: auto-move floating major version tag on release

### DIFF
--- a/.github/workflows/move-floating-tag.yml
+++ b/.github/workflows/move-floating-tag.yml
@@ -1,0 +1,20 @@
+name: Move Floating Tag
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: write
+
+jobs:
+  update-tag:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Move major version tag
+        run: |
+          VERSION="${{ github.event.release.tag_name }}"
+          MAJOR="${VERSION%%.*}"
+          git tag -f "$MAJOR" "$VERSION"
+          git push --force origin "$MAJOR"

--- a/action.yml
+++ b/action.yml
@@ -27,8 +27,9 @@ inputs:
   update-mode:
     description: |
       How many PRs to update per run. Options:
-        all  - Update all eligible PRs (may cause CI stampede)
-        next - Update only the next PR to merge (sequential, CI-efficient)
+        all          - Update all eligible PRs (may cause CI stampede)
+        next         - Update only the next PR to merge (sequential, CI-efficient)
+        test-branch  - Create merge-test branches instead of modifying PR branches
     required: false
     default: "all"
   cancel-stale-ci:
@@ -67,6 +68,14 @@ inputs:
     description: "Path to repo config file for label mappings and settings (requires checkout step)"
     required: false
     default: ".github/auto-update.yml"
+  test-branch-prefix:
+    description: "Branch prefix for test-branch mode (default: merge-test)"
+    required: false
+    default: "merge-test"
+  status-context:
+    description: "Commit status context name for test-branch mode (default: merge-test)"
+    required: false
+    default: "merge-test"
 
 outputs:
   updated:

--- a/dist/index.js
+++ b/dist/index.js
@@ -34131,6 +34131,7 @@ const filter_1 = __nccwpck_require__(9037);
 const filter_2 = __nccwpck_require__(9037);
 const priority_1 = __nccwpck_require__(1759);
 const update_branches_1 = __nccwpck_require__(3315);
+const test_branch_1 = __nccwpck_require__(2564);
 function getInputs() {
     const excludeStr = core.getInput("exclude-labels");
     return {
@@ -34148,6 +34149,8 @@ function getInputs() {
         maxUpdates: parseInt(core.getInput("max-updates"), 10) || 0,
         priorityLabels: core.getInput("priority-labels"),
         configFile: core.getInput("config-file"),
+        testBranchPrefix: core.getInput("test-branch-prefix") || "merge-test",
+        statusContext: core.getInput("status-context") || "merge-test",
     };
 }
 async function run() {
@@ -34196,8 +34199,20 @@ async function run() {
             core.info(`  #${pr.number} priority=${pr.priority} [${pr.branch}]`);
         }
         core.endGroup();
-        // Update branches
-        const result = await (0, update_branches_1.updateBranches)(octokit, owner, repo, sorted, inputs);
+        // Process PRs based on mode
+        let result;
+        if (inputs.updateMode === "test-branch") {
+            result = await (0, test_branch_1.processTestBranches)(octokit, owner, repo, sorted, inputs);
+            // Clean up test branches for closed/merged PRs
+            const openPrNumbers = new Set(sorted.map((pr) => pr.number));
+            const cleaned = await (0, test_branch_1.cleanupTestBranches)(octokit, owner, repo, openPrNumbers, inputs.testBranchPrefix);
+            if (cleaned > 0) {
+                core.info(`Cleaned up ${cleaned} stale test branch(es)`);
+            }
+        }
+        else {
+            result = await (0, update_branches_1.updateBranches)(octokit, owner, repo, sorted, inputs);
+        }
         // Summary
         (0, update_branches_1.writeSummary)(result, sorted);
     }
@@ -34354,6 +34369,365 @@ function prioritizeAndSort(prs, map) {
             return b.priority - a.priority;
         return a.number - b.number;
     });
+}
+
+
+/***/ }),
+
+/***/ 2564:
+/***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
+
+"use strict";
+
+var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    var desc = Object.getOwnPropertyDescriptor(m, k);
+    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+      desc = { enumerable: true, get: function() { return m[k]; } };
+    }
+    Object.defineProperty(o, k2, desc);
+}) : (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    o[k2] = m[k];
+}));
+var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
+    Object.defineProperty(o, "default", { enumerable: true, value: v });
+}) : function(o, v) {
+    o["default"] = v;
+});
+var __importStar = (this && this.__importStar) || (function () {
+    var ownKeys = function(o) {
+        ownKeys = Object.getOwnPropertyNames || function (o) {
+            var ar = [];
+            for (var k in o) if (Object.prototype.hasOwnProperty.call(o, k)) ar[ar.length] = k;
+            return ar;
+        };
+        return ownKeys(o);
+    };
+    return function (mod) {
+        if (mod && mod.__esModule) return mod;
+        var result = {};
+        if (mod != null) for (var k = ownKeys(mod), i = 0; i < k.length; i++) if (k[i] !== "default") __createBinding(result, mod, k[i]);
+        __setModuleDefault(result, mod);
+        return result;
+    };
+})();
+Object.defineProperty(exports, "__esModule", ({ value: true }));
+exports.processTestBranches = processTestBranches;
+exports.cleanupTestBranches = cleanupTestBranches;
+const core = __importStar(__nccwpck_require__(7484));
+/**
+ * Get the SHA of the base branch (main).
+ */
+async function getBaseBranchSha(octokit, owner, repo) {
+    const { data } = await octokit.rest.git.getRef({
+        owner,
+        repo,
+        ref: "heads/main",
+    });
+    return data.object.sha;
+}
+/**
+ * Check if a test branch ref exists and return its SHA if so.
+ */
+async function getTestBranchSha(octokit, owner, repo, testBranch) {
+    try {
+        const { data } = await octokit.rest.git.getRef({
+            owner,
+            repo,
+            ref: `heads/${testBranch}`,
+        });
+        return data.object.sha;
+    }
+    catch (error) {
+        const status = error.status ?? 0;
+        if (status === 404)
+            return null;
+        throw error;
+    }
+}
+/**
+ * Create a merge commit combining main and the PR branch.
+ * Returns the SHA of the merge commit, or null if there's a conflict.
+ */
+async function createMergeCommit(octokit, owner, repo, baseSha, headSha, prNumber) {
+    try {
+        const { data } = await octokit.rest.git.createTree({
+            owner,
+            repo,
+            base_tree: baseSha,
+            tree: [],
+        });
+        // Use the merge API to create a proper merge
+        const { data: mergeData } = await octokit.rest.repos.merge({
+            owner,
+            repo,
+            base: `refs/heads/__merge-test-temp-${prNumber}`,
+            head: headSha.substring(0, 7),
+        });
+        return mergeData.sha;
+    }
+    catch {
+        return null;
+    }
+}
+/**
+ * Create or update a test branch ref.
+ */
+async function createOrUpdateTestBranch(octokit, owner, repo, testBranch, baseSha, prBranch, prNumber) {
+    try {
+        // Use the merge API: merge the PR branch into a test branch based on main.
+        // First, create or reset the test branch to point at main's HEAD.
+        const existingSha = await getTestBranchSha(octokit, owner, repo, testBranch);
+        if (existingSha) {
+            // Update existing ref to main HEAD
+            await octokit.rest.git.updateRef({
+                owner,
+                repo,
+                ref: `heads/${testBranch}`,
+                sha: baseSha,
+                force: true,
+            });
+        }
+        else {
+            // Create new ref at main HEAD
+            await octokit.rest.git.createRef({
+                owner,
+                repo,
+                ref: `refs/heads/${testBranch}`,
+                sha: baseSha,
+            });
+        }
+        // Now merge the PR branch into the test branch
+        await octokit.rest.repos.merge({
+            owner,
+            repo,
+            base: testBranch,
+            head: prBranch,
+            commit_message: `Merge-test: PR #${prNumber} with latest main`,
+        });
+        return "created";
+    }
+    catch (error) {
+        const status = error.status ?? 0;
+        const message = String(error.message ?? "");
+        if (status === 409 || /merge conflict/i.test(message) || /conflict/i.test(message)) {
+            // Clean up the test branch on conflict
+            await deleteTestBranch(octokit, owner, repo, testBranch);
+            return "conflict";
+        }
+        // Clean up on error too
+        try {
+            await deleteTestBranch(octokit, owner, repo, testBranch);
+        }
+        catch {
+            // ignore cleanup errors
+        }
+        return "error";
+    }
+}
+/**
+ * Post a commit status on the PR's head commit.
+ */
+async function postCommitStatus(octokit, owner, repo, sha, state, context, description, targetUrl) {
+    await octokit.rest.repos.createCommitStatus({
+        owner,
+        repo,
+        sha,
+        state,
+        context,
+        description,
+        target_url: targetUrl,
+    });
+}
+/**
+ * Delete a test branch ref.
+ */
+async function deleteTestBranch(octokit, owner, repo, testBranch) {
+    try {
+        await octokit.rest.git.deleteRef({
+            owner,
+            repo,
+            ref: `heads/${testBranch}`,
+        });
+    }
+    catch (error) {
+        const status = error.status ?? 0;
+        if (status !== 404 && status !== 422) {
+            core.warning(`Failed to delete test branch ${testBranch}: ${error}`);
+        }
+    }
+}
+/**
+ * Check the current commit status for a given context on a SHA.
+ */
+async function getCommitStatus(octokit, owner, repo, sha, context) {
+    try {
+        const { data } = await octokit.rest.repos.listCommitStatusesForRef({
+            owner,
+            repo,
+            ref: sha,
+            per_page: 100,
+        });
+        // Statuses are returned newest first; find the latest for our context
+        const status = data.find((s) => s.context === context);
+        return status ? status.state : null;
+    }
+    catch {
+        return null;
+    }
+}
+/**
+ * Check if the test branch's CI has completed by looking at workflow runs.
+ */
+async function checkTestBranchCI(octokit, owner, repo, testBranch, ciWorkflow) {
+    try {
+        const params = {
+            owner,
+            repo,
+            branch: testBranch,
+            per_page: 5,
+        };
+        let runs;
+        if (ciWorkflow) {
+            runs = await octokit.rest.actions.listWorkflowRuns({
+                ...params,
+                workflow_id: ciWorkflow,
+            });
+        }
+        else {
+            runs = await octokit.rest.actions.listWorkflowRunsForRepo(params);
+        }
+        if (runs.data.workflow_runs.length === 0) {
+            return "not_found";
+        }
+        const latest = runs.data.workflow_runs[0];
+        if (latest.status === "completed") {
+            return latest.conclusion === "success" ? "success" : "failure";
+        }
+        return "pending";
+    }
+    catch {
+        return "not_found";
+    }
+}
+/**
+ * Handle a PR that has merge conflicts in test-branch mode.
+ */
+async function handleConflict(octokit, owner, repo, prNumber, prSha, inputs) {
+    // Post failure status
+    await postCommitStatus(octokit, owner, repo, prSha, "failure", inputs.statusContext, "Merge conflict with main");
+    // Add conflict label
+    if (inputs.conflictLabel) {
+        try {
+            await octokit.rest.issues.addLabels({
+                owner, repo, issue_number: prNumber,
+                labels: [inputs.conflictLabel],
+            });
+        }
+        catch (error) {
+            core.warning(`Failed to add conflict label to PR #${prNumber}: ${error}`);
+        }
+    }
+}
+/**
+ * Process PRs in test-branch mode.
+ *
+ * For each eligible PR:
+ * 1. Check if a test branch already exists and CI has completed
+ * 2. If CI passed, post success status on PR head commit
+ * 3. If no test branch or main has advanced, create/update test branch
+ * 4. Post pending status on PR head commit
+ */
+async function processTestBranches(octokit, owner, repo, prs, inputs) {
+    const result = { updated: 0, conflicts: 0, skipped: 0, errors: 0 };
+    const baseSha = await getBaseBranchSha(octokit, owner, repo);
+    for (const pr of prs) {
+        core.startGroup(`PR #${pr.number} (priority=${pr.priority})`);
+        const testBranch = `${inputs.testBranchPrefix}/pr-${pr.number}`;
+        // Check if test branch already exists
+        const testBranchSha = await getTestBranchSha(octokit, owner, repo, testBranch);
+        if (testBranchSha) {
+            // Test branch exists — check if CI has completed on it
+            const ciStatus = await checkTestBranchCI(octokit, owner, repo, testBranch, inputs.ciWorkflow);
+            if (ciStatus === "success") {
+                // CI passed on test branch — post success status on PR
+                core.info(`Test branch CI passed — posting success status on PR #${pr.number}`);
+                await postCommitStatus(octokit, owner, repo, pr.sha, "success", inputs.statusContext, `Merge test passed (main@${baseSha.substring(0, 7)})`);
+                result.skipped++;
+                core.endGroup();
+                continue;
+            }
+            if (ciStatus === "failure") {
+                // CI failed — post failure status, will need investigation
+                core.info(`Test branch CI failed — posting failure status on PR #${pr.number}`);
+                await postCommitStatus(octokit, owner, repo, pr.sha, "failure", inputs.statusContext, "Merge test failed — CI did not pass on test branch");
+                result.errors++;
+                core.endGroup();
+                continue;
+            }
+            if (ciStatus === "pending") {
+                // CI still running — don't interrupt
+                core.info(`Test branch CI still running for PR #${pr.number}, skipping`);
+                result.skipped++;
+                core.endGroup();
+                continue;
+            }
+            // CI not found — test branch may be stale (main advanced). Recreate it.
+            core.info(`Test branch exists but no CI found — recreating for PR #${pr.number}`);
+        }
+        // Create or update test branch (main + PR)
+        core.info(`Creating test branch ${testBranch} for PR #${pr.number}`);
+        const outcome = await createOrUpdateTestBranch(octokit, owner, repo, testBranch, baseSha, pr.branch, pr.number);
+        switch (outcome) {
+            case "created":
+                core.info(`Test branch ${testBranch} created successfully`);
+                await postCommitStatus(octokit, owner, repo, pr.sha, "pending", inputs.statusContext, `Merge test in progress (main@${baseSha.substring(0, 7)})`);
+                result.updated++;
+                break;
+            case "conflict":
+                core.info(`PR #${pr.number} has merge conflicts with main`);
+                result.conflicts++;
+                await handleConflict(octokit, owner, repo, pr.number, pr.sha, inputs);
+                break;
+            case "error":
+                core.warning(`Failed to create test branch for PR #${pr.number}`);
+                result.errors++;
+                break;
+        }
+        core.endGroup();
+    }
+    return result;
+}
+/**
+ * Clean up test branches for PRs that are no longer open.
+ */
+async function cleanupTestBranches(octokit, owner, repo, openPrNumbers, prefix) {
+    let cleaned = 0;
+    try {
+        // List all refs matching the test branch prefix
+        const { data } = await octokit.rest.git.listMatchingRefs({
+            owner,
+            repo,
+            ref: `heads/${prefix}/pr-`,
+        });
+        for (const ref of data) {
+            // Extract PR number from ref name (e.g., "merge-test/pr-123")
+            const match = ref.ref.match(/\/pr-(\d+)$/);
+            if (!match)
+                continue;
+            const prNumber = parseInt(match[1], 10);
+            if (!openPrNumbers.has(prNumber)) {
+                core.info(`Cleaning up stale test branch: ${ref.ref}`);
+                await deleteTestBranch(octokit, owner, repo, ref.ref.replace("refs/heads/", ""));
+                cleaned++;
+            }
+        }
+    }
+    catch (error) {
+        core.warning(`Failed to cleanup test branches: ${error}`);
+    }
+    return cleaned;
 }
 
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -5,6 +5,7 @@ import { transformPRs } from "./filter";
 import { filterPRs } from "./filter";
 import { buildPriorityMap, prioritizeAndSort } from "./priority";
 import { updateBranches, writeSummary } from "./update-branches";
+import { processTestBranches, cleanupTestBranches } from "./test-branch";
 
 function getInputs(): ActionInputs {
   const excludeStr = core.getInput("exclude-labels");
@@ -24,6 +25,8 @@ function getInputs(): ActionInputs {
     maxUpdates: parseInt(core.getInput("max-updates"), 10) || 0,
     priorityLabels: core.getInput("priority-labels"),
     configFile: core.getInput("config-file"),
+    testBranchPrefix: core.getInput("test-branch-prefix") || "merge-test",
+    statusContext: core.getInput("status-context") || "merge-test",
   };
 }
 
@@ -87,8 +90,22 @@ async function run(): Promise<void> {
 
     core.endGroup();
 
-    // Update branches
-    const result = await updateBranches(octokit, owner, repo, sorted, inputs);
+    // Process PRs based on mode
+    let result;
+    if (inputs.updateMode === "test-branch") {
+      result = await processTestBranches(octokit, owner, repo, sorted, inputs);
+
+      // Clean up test branches for closed/merged PRs
+      const openPrNumbers = new Set(sorted.map((pr) => pr.number));
+      const cleaned = await cleanupTestBranches(
+        octokit, owner, repo, openPrNumbers, inputs.testBranchPrefix
+      );
+      if (cleaned > 0) {
+        core.info(`Cleaned up ${cleaned} stale test branch(es)`);
+      }
+    } else {
+      result = await updateBranches(octokit, owner, repo, sorted, inputs);
+    }
 
     // Summary
     writeSummary(result, sorted);

--- a/src/test-branch.ts
+++ b/src/test-branch.ts
@@ -1,0 +1,441 @@
+import * as core from "@actions/core";
+import type { GitHub } from "@actions/github/lib/utils";
+import type { ActionInputs, PrioritizedPR, UpdateResult } from "./types";
+
+type Octokit = InstanceType<typeof GitHub>;
+
+/**
+ * Get the SHA of the base branch (main).
+ */
+async function getBaseBranchSha(
+  octokit: Octokit,
+  owner: string,
+  repo: string
+): Promise<string> {
+  const { data } = await octokit.rest.git.getRef({
+    owner,
+    repo,
+    ref: "heads/main",
+  });
+  return data.object.sha;
+}
+
+/**
+ * Check if a test branch ref exists and return its SHA if so.
+ */
+async function getTestBranchSha(
+  octokit: Octokit,
+  owner: string,
+  repo: string,
+  testBranch: string
+): Promise<string | null> {
+  try {
+    const { data } = await octokit.rest.git.getRef({
+      owner,
+      repo,
+      ref: `heads/${testBranch}`,
+    });
+    return data.object.sha;
+  } catch (error: unknown) {
+    const status = (error as { status?: number }).status ?? 0;
+    if (status === 404) return null;
+    throw error;
+  }
+}
+
+/**
+ * Create a merge commit combining main and the PR branch.
+ * Returns the SHA of the merge commit, or null if there's a conflict.
+ */
+async function createMergeCommit(
+  octokit: Octokit,
+  owner: string,
+  repo: string,
+  baseSha: string,
+  headSha: string,
+  prNumber: number
+): Promise<string | null> {
+  try {
+    const { data } = await octokit.rest.git.createTree({
+      owner,
+      repo,
+      base_tree: baseSha,
+      tree: [],
+    });
+
+    // Use the merge API to create a proper merge
+    const { data: mergeData } = await octokit.rest.repos.merge({
+      owner,
+      repo,
+      base: `refs/heads/__merge-test-temp-${prNumber}`,
+      head: headSha.substring(0, 7),
+    });
+
+    return mergeData.sha;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Create or update a test branch ref.
+ */
+async function createOrUpdateTestBranch(
+  octokit: Octokit,
+  owner: string,
+  repo: string,
+  testBranch: string,
+  baseSha: string,
+  prBranch: string,
+  prNumber: number
+): Promise<"created" | "conflict" | "error"> {
+  try {
+    // Use the merge API: merge the PR branch into a test branch based on main.
+    // First, create or reset the test branch to point at main's HEAD.
+    const existingSha = await getTestBranchSha(octokit, owner, repo, testBranch);
+
+    if (existingSha) {
+      // Update existing ref to main HEAD
+      await octokit.rest.git.updateRef({
+        owner,
+        repo,
+        ref: `heads/${testBranch}`,
+        sha: baseSha,
+        force: true,
+      });
+    } else {
+      // Create new ref at main HEAD
+      await octokit.rest.git.createRef({
+        owner,
+        repo,
+        ref: `refs/heads/${testBranch}`,
+        sha: baseSha,
+      });
+    }
+
+    // Now merge the PR branch into the test branch
+    await octokit.rest.repos.merge({
+      owner,
+      repo,
+      base: testBranch,
+      head: prBranch,
+      commit_message: `Merge-test: PR #${prNumber} with latest main`,
+    });
+
+    return "created";
+  } catch (error: unknown) {
+    const status = (error as { status?: number }).status ?? 0;
+    const message = String((error as { message?: string }).message ?? "");
+
+    if (status === 409 || /merge conflict/i.test(message) || /conflict/i.test(message)) {
+      // Clean up the test branch on conflict
+      await deleteTestBranch(octokit, owner, repo, testBranch);
+      return "conflict";
+    }
+
+    // Clean up on error too
+    try {
+      await deleteTestBranch(octokit, owner, repo, testBranch);
+    } catch {
+      // ignore cleanup errors
+    }
+    return "error";
+  }
+}
+
+/**
+ * Post a commit status on the PR's head commit.
+ */
+async function postCommitStatus(
+  octokit: Octokit,
+  owner: string,
+  repo: string,
+  sha: string,
+  state: "pending" | "success" | "failure" | "error",
+  context: string,
+  description: string,
+  targetUrl?: string
+): Promise<void> {
+  await octokit.rest.repos.createCommitStatus({
+    owner,
+    repo,
+    sha,
+    state,
+    context,
+    description,
+    target_url: targetUrl,
+  });
+}
+
+/**
+ * Delete a test branch ref.
+ */
+async function deleteTestBranch(
+  octokit: Octokit,
+  owner: string,
+  repo: string,
+  testBranch: string
+): Promise<void> {
+  try {
+    await octokit.rest.git.deleteRef({
+      owner,
+      repo,
+      ref: `heads/${testBranch}`,
+    });
+  } catch (error: unknown) {
+    const status = (error as { status?: number }).status ?? 0;
+    if (status !== 404 && status !== 422) {
+      core.warning(`Failed to delete test branch ${testBranch}: ${error}`);
+    }
+  }
+}
+
+/**
+ * Check the current commit status for a given context on a SHA.
+ */
+async function getCommitStatus(
+  octokit: Octokit,
+  owner: string,
+  repo: string,
+  sha: string,
+  context: string
+): Promise<"pending" | "success" | "failure" | "error" | null> {
+  try {
+    const { data } = await octokit.rest.repos.listCommitStatusesForRef({
+      owner,
+      repo,
+      ref: sha,
+      per_page: 100,
+    });
+
+    // Statuses are returned newest first; find the latest for our context
+    const status = data.find((s) => s.context === context);
+    return status ? (status.state as "pending" | "success" | "failure" | "error") : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Check if the test branch's CI has completed by looking at workflow runs.
+ */
+async function checkTestBranchCI(
+  octokit: Octokit,
+  owner: string,
+  repo: string,
+  testBranch: string,
+  ciWorkflow: string
+): Promise<"success" | "failure" | "pending" | "not_found"> {
+  try {
+    const params: {
+      owner: string;
+      repo: string;
+      branch: string;
+      per_page: number;
+      workflow_id?: string;
+    } = {
+      owner,
+      repo,
+      branch: testBranch,
+      per_page: 5,
+    };
+
+    let runs;
+    if (ciWorkflow) {
+      runs = await octokit.rest.actions.listWorkflowRuns({
+        ...params,
+        workflow_id: ciWorkflow,
+      });
+    } else {
+      runs = await octokit.rest.actions.listWorkflowRunsForRepo(params);
+    }
+
+    if (runs.data.workflow_runs.length === 0) {
+      return "not_found";
+    }
+
+    const latest = runs.data.workflow_runs[0];
+    if (latest.status === "completed") {
+      return latest.conclusion === "success" ? "success" : "failure";
+    }
+
+    return "pending";
+  } catch {
+    return "not_found";
+  }
+}
+
+/**
+ * Handle a PR that has merge conflicts in test-branch mode.
+ */
+async function handleConflict(
+  octokit: Octokit,
+  owner: string,
+  repo: string,
+  prNumber: number,
+  prSha: string,
+  inputs: ActionInputs
+): Promise<void> {
+  // Post failure status
+  await postCommitStatus(
+    octokit, owner, repo, prSha, "failure",
+    inputs.statusContext,
+    "Merge conflict with main"
+  );
+
+  // Add conflict label
+  if (inputs.conflictLabel) {
+    try {
+      await octokit.rest.issues.addLabels({
+        owner, repo, issue_number: prNumber,
+        labels: [inputs.conflictLabel],
+      });
+    } catch (error) {
+      core.warning(`Failed to add conflict label to PR #${prNumber}: ${error}`);
+    }
+  }
+}
+
+/**
+ * Process PRs in test-branch mode.
+ *
+ * For each eligible PR:
+ * 1. Check if a test branch already exists and CI has completed
+ * 2. If CI passed, post success status on PR head commit
+ * 3. If no test branch or main has advanced, create/update test branch
+ * 4. Post pending status on PR head commit
+ */
+export async function processTestBranches(
+  octokit: Octokit,
+  owner: string,
+  repo: string,
+  prs: PrioritizedPR[],
+  inputs: ActionInputs
+): Promise<UpdateResult> {
+  const result: UpdateResult = { updated: 0, conflicts: 0, skipped: 0, errors: 0 };
+  const baseSha = await getBaseBranchSha(octokit, owner, repo);
+
+  for (const pr of prs) {
+    core.startGroup(`PR #${pr.number} (priority=${pr.priority})`);
+
+    const testBranch = `${inputs.testBranchPrefix}/pr-${pr.number}`;
+
+    // Check if test branch already exists
+    const testBranchSha = await getTestBranchSha(octokit, owner, repo, testBranch);
+
+    if (testBranchSha) {
+      // Test branch exists — check if CI has completed on it
+      const ciStatus = await checkTestBranchCI(
+        octokit, owner, repo, testBranch, inputs.ciWorkflow
+      );
+
+      if (ciStatus === "success") {
+        // CI passed on test branch — post success status on PR
+        core.info(`Test branch CI passed — posting success status on PR #${pr.number}`);
+        await postCommitStatus(
+          octokit, owner, repo, pr.sha, "success",
+          inputs.statusContext,
+          `Merge test passed (main@${baseSha.substring(0, 7)})`
+        );
+        result.skipped++;
+        core.endGroup();
+        continue;
+      }
+
+      if (ciStatus === "failure") {
+        // CI failed — post failure status, will need investigation
+        core.info(`Test branch CI failed — posting failure status on PR #${pr.number}`);
+        await postCommitStatus(
+          octokit, owner, repo, pr.sha, "failure",
+          inputs.statusContext,
+          "Merge test failed — CI did not pass on test branch"
+        );
+        result.errors++;
+        core.endGroup();
+        continue;
+      }
+
+      if (ciStatus === "pending") {
+        // CI still running — don't interrupt
+        core.info(`Test branch CI still running for PR #${pr.number}, skipping`);
+        result.skipped++;
+        core.endGroup();
+        continue;
+      }
+
+      // CI not found — test branch may be stale (main advanced). Recreate it.
+      core.info(`Test branch exists but no CI found — recreating for PR #${pr.number}`);
+    }
+
+    // Create or update test branch (main + PR)
+    core.info(`Creating test branch ${testBranch} for PR #${pr.number}`);
+
+    const outcome = await createOrUpdateTestBranch(
+      octokit, owner, repo, testBranch, baseSha, pr.branch, pr.number
+    );
+
+    switch (outcome) {
+      case "created":
+        core.info(`Test branch ${testBranch} created successfully`);
+        await postCommitStatus(
+          octokit, owner, repo, pr.sha, "pending",
+          inputs.statusContext,
+          `Merge test in progress (main@${baseSha.substring(0, 7)})`
+        );
+        result.updated++;
+        break;
+      case "conflict":
+        core.info(`PR #${pr.number} has merge conflicts with main`);
+        result.conflicts++;
+        await handleConflict(octokit, owner, repo, pr.number, pr.sha, inputs);
+        break;
+      case "error":
+        core.warning(`Failed to create test branch for PR #${pr.number}`);
+        result.errors++;
+        break;
+    }
+
+    core.endGroup();
+  }
+
+  return result;
+}
+
+/**
+ * Clean up test branches for PRs that are no longer open.
+ */
+export async function cleanupTestBranches(
+  octokit: Octokit,
+  owner: string,
+  repo: string,
+  openPrNumbers: Set<number>,
+  prefix: string
+): Promise<number> {
+  let cleaned = 0;
+
+  try {
+    // List all refs matching the test branch prefix
+    const { data } = await octokit.rest.git.listMatchingRefs({
+      owner,
+      repo,
+      ref: `heads/${prefix}/pr-`,
+    });
+
+    for (const ref of data) {
+      // Extract PR number from ref name (e.g., "merge-test/pr-123")
+      const match = ref.ref.match(/\/pr-(\d+)$/);
+      if (!match) continue;
+
+      const prNumber = parseInt(match[1], 10);
+      if (!openPrNumbers.has(prNumber)) {
+        core.info(`Cleaning up stale test branch: ${ref.ref}`);
+        await deleteTestBranch(octokit, owner, repo, ref.ref.replace("refs/heads/", ""));
+        cleaned++;
+      }
+    }
+  } catch (error) {
+    core.warning(`Failed to cleanup test branches: ${error}`);
+  }
+
+  return cleaned;
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -15,7 +15,7 @@ export interface ActionInputs {
   token: string;
   filter: "all" | "auto-merge" | "label" | "auto-merge+label";
   label: string;
-  updateMode: "all" | "next";
+  updateMode: "all" | "next" | "test-branch";
   cancelStaleCi: boolean;
   ciWorkflow: string;
   conflictLabel: string;
@@ -24,6 +24,8 @@ export interface ActionInputs {
   maxUpdates: number;
   priorityLabels: string;
   configFile: string;
+  testBranchPrefix: string;
+  statusContext: string;
 }
 
 export interface PriorityMap {

--- a/tests/test-branch.test.ts
+++ b/tests/test-branch.test.ts
@@ -1,0 +1,354 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { ActionInputs, PrioritizedPR } from "../src/types";
+
+vi.mock("@actions/core", () => ({
+  info: vi.fn(),
+  warning: vi.fn(),
+  startGroup: vi.fn(),
+  endGroup: vi.fn(),
+  setOutput: vi.fn(),
+  summary: {
+    addRaw: vi.fn().mockReturnThis(),
+    write: vi.fn(),
+  },
+}));
+
+import { processTestBranches, cleanupTestBranches } from "../src/test-branch";
+
+const defaultInputs: ActionInputs = {
+  token: "test",
+  filter: "all",
+  label: "automerge",
+  updateMode: "test-branch",
+  cancelStaleCi: false,
+  ciWorkflow: "",
+  conflictLabel: "needs-rebase",
+  conflictComment: true,
+  excludeLabels: [],
+  maxUpdates: 0,
+  priorityLabels: "",
+  configFile: "",
+  testBranchPrefix: "merge-test",
+  statusContext: "merge-test",
+};
+
+const makePR = (number: number, priority = 0): PrioritizedPR => ({
+  number,
+  branch: `feature-${number}`,
+  sha: `sha-${number}`,
+  autoMerge: false,
+  labels: [],
+  isDraft: false,
+  priority,
+});
+
+const mainSha = "abc1234567890";
+
+function makeOctokit(overrides: Record<string, unknown> = {}) {
+  return {
+    rest: {
+      git: {
+        getRef: vi.fn().mockImplementation(({ ref }: { ref: string }) => {
+          if (ref === "heads/main") {
+            return Promise.resolve({ data: { object: { sha: mainSha } } });
+          }
+          // Test branch doesn't exist by default
+          const error = new Error("Not Found") as Error & { status: number };
+          error.status = 404;
+          return Promise.reject(error);
+        }),
+        createRef: vi.fn().mockResolvedValue({}),
+        updateRef: vi.fn().mockResolvedValue({}),
+        deleteRef: vi.fn().mockResolvedValue({}),
+        listMatchingRefs: vi.fn().mockResolvedValue({ data: [] }),
+        ...(overrides.git as Record<string, unknown> || {}),
+      },
+      repos: {
+        merge: vi.fn().mockResolvedValue({ data: { sha: "merge-sha-123" } }),
+        createCommitStatus: vi.fn().mockResolvedValue({}),
+        listCommitStatusesForRef: vi.fn().mockResolvedValue({ data: [] }),
+        ...(overrides.repos as Record<string, unknown> || {}),
+      },
+      pulls: {
+        get: vi.fn().mockResolvedValue({ data: { mergeable_state: "behind" } }),
+        updateBranch: vi.fn().mockResolvedValue({}),
+        ...(overrides.pulls as Record<string, unknown> || {}),
+      },
+      issues: {
+        addLabels: vi.fn().mockResolvedValue({}),
+        createComment: vi.fn().mockResolvedValue({}),
+        ...(overrides.issues as Record<string, unknown> || {}),
+      },
+      actions: {
+        listWorkflowRuns: vi.fn().mockResolvedValue({ data: { workflow_runs: [] } }),
+        listWorkflowRunsForRepo: vi.fn().mockResolvedValue({ data: { workflow_runs: [] } }),
+        cancelWorkflowRun: vi.fn().mockResolvedValue({}),
+        ...(overrides.actions as Record<string, unknown> || {}),
+      },
+    },
+  } as any;
+}
+
+describe("processTestBranches", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("creates test branch and posts pending status for a PR", async () => {
+    const octokit = makeOctokit();
+    const prs = [makePR(42)];
+
+    const result = await processTestBranches(octokit, "owner", "repo", prs, defaultInputs);
+
+    expect(result.updated).toBe(1);
+
+    // Should create ref at main SHA
+    expect(octokit.rest.git.createRef).toHaveBeenCalledWith({
+      owner: "owner",
+      repo: "repo",
+      ref: "refs/heads/merge-test/pr-42",
+      sha: mainSha,
+    });
+
+    // Should merge PR branch into test branch
+    expect(octokit.rest.repos.merge).toHaveBeenCalledWith({
+      owner: "owner",
+      repo: "repo",
+      base: "merge-test/pr-42",
+      head: "feature-42",
+      commit_message: "Merge-test: PR #42 with latest main",
+    });
+
+    // Should post pending status
+    expect(octokit.rest.repos.createCommitStatus).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sha: "sha-42",
+        state: "pending",
+        context: "merge-test",
+      })
+    );
+  });
+
+  it("skips PR when test branch CI is still running", async () => {
+    const octokit = makeOctokit({
+      git: {
+        getRef: vi.fn().mockImplementation(({ ref }: { ref: string }) => {
+          if (ref === "heads/main") {
+            return Promise.resolve({ data: { object: { sha: mainSha } } });
+          }
+          // Test branch exists
+          return Promise.resolve({ data: { object: { sha: "test-branch-sha" } } });
+        }),
+      },
+      actions: {
+        listWorkflowRunsForRepo: vi.fn().mockResolvedValue({
+          data: {
+            workflow_runs: [{
+              status: "in_progress",
+              conclusion: null,
+            }],
+          },
+        }),
+      },
+    });
+
+    const result = await processTestBranches(octokit, "owner", "repo", [makePR(42)], defaultInputs);
+
+    expect(result.skipped).toBe(1);
+    expect(result.updated).toBe(0);
+    // Should NOT create or update any refs
+    expect(octokit.rest.git.createRef).not.toHaveBeenCalled();
+    expect(octokit.rest.git.updateRef).not.toHaveBeenCalled();
+  });
+
+  it("posts success status when test branch CI passes", async () => {
+    const octokit = makeOctokit({
+      git: {
+        getRef: vi.fn().mockImplementation(({ ref }: { ref: string }) => {
+          if (ref === "heads/main") {
+            return Promise.resolve({ data: { object: { sha: mainSha } } });
+          }
+          return Promise.resolve({ data: { object: { sha: "test-branch-sha" } } });
+        }),
+      },
+      actions: {
+        listWorkflowRunsForRepo: vi.fn().mockResolvedValue({
+          data: {
+            workflow_runs: [{
+              status: "completed",
+              conclusion: "success",
+            }],
+          },
+        }),
+      },
+    });
+
+    const result = await processTestBranches(octokit, "owner", "repo", [makePR(42)], defaultInputs);
+
+    expect(result.skipped).toBe(1);
+    expect(octokit.rest.repos.createCommitStatus).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sha: "sha-42",
+        state: "success",
+        context: "merge-test",
+      })
+    );
+  });
+
+  it("posts failure status when test branch CI fails", async () => {
+    const octokit = makeOctokit({
+      git: {
+        getRef: vi.fn().mockImplementation(({ ref }: { ref: string }) => {
+          if (ref === "heads/main") {
+            return Promise.resolve({ data: { object: { sha: mainSha } } });
+          }
+          return Promise.resolve({ data: { object: { sha: "test-branch-sha" } } });
+        }),
+      },
+      actions: {
+        listWorkflowRunsForRepo: vi.fn().mockResolvedValue({
+          data: {
+            workflow_runs: [{
+              status: "completed",
+              conclusion: "failure",
+            }],
+          },
+        }),
+      },
+    });
+
+    const result = await processTestBranches(octokit, "owner", "repo", [makePR(42)], defaultInputs);
+
+    expect(result.errors).toBe(1);
+    expect(octokit.rest.repos.createCommitStatus).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sha: "sha-42",
+        state: "failure",
+        context: "merge-test",
+      })
+    );
+  });
+
+  it("handles merge conflict when creating test branch", async () => {
+    const mergeError = new Error("Merge conflict") as Error & { status: number };
+    mergeError.status = 409;
+
+    const octokit = makeOctokit({
+      repos: {
+        merge: vi.fn().mockRejectedValue(mergeError),
+        createCommitStatus: vi.fn().mockResolvedValue({}),
+        listCommitStatusesForRef: vi.fn().mockResolvedValue({ data: [] }),
+      },
+    });
+
+    const result = await processTestBranches(octokit, "owner", "repo", [makePR(42)], defaultInputs);
+
+    expect(result.conflicts).toBe(1);
+    expect(result.updated).toBe(0);
+
+    // Should post failure status
+    expect(octokit.rest.repos.createCommitStatus).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sha: "sha-42",
+        state: "failure",
+        context: "merge-test",
+        description: "Merge conflict with main",
+      })
+    );
+
+    // Should add conflict label
+    expect(octokit.rest.issues.addLabels).toHaveBeenCalledWith(
+      expect.objectContaining({ labels: ["needs-rebase"] })
+    );
+  });
+
+  it("updates existing test branch when main has advanced", async () => {
+    const octokit = makeOctokit({
+      git: {
+        getRef: vi.fn().mockImplementation(({ ref }: { ref: string }) => {
+          if (ref === "heads/main") {
+            return Promise.resolve({ data: { object: { sha: mainSha } } });
+          }
+          // Test branch exists but no CI found (stale)
+          return Promise.resolve({ data: { object: { sha: "old-test-sha" } } });
+        }),
+      },
+    });
+
+    const result = await processTestBranches(octokit, "owner", "repo", [makePR(42)], defaultInputs);
+
+    expect(result.updated).toBe(1);
+
+    // Should force-update the existing ref to main SHA first
+    expect(octokit.rest.git.updateRef).toHaveBeenCalledWith({
+      owner: "owner",
+      repo: "repo",
+      ref: "heads/merge-test/pr-42",
+      sha: mainSha,
+      force: true,
+    });
+
+    // Then merge PR into it
+    expect(octokit.rest.repos.merge).toHaveBeenCalled();
+  });
+
+  it("processes multiple PRs", async () => {
+    const octokit = makeOctokit();
+    const prs = [makePR(1), makePR(2), makePR(3)];
+
+    const result = await processTestBranches(octokit, "owner", "repo", prs, defaultInputs);
+
+    expect(result.updated).toBe(3);
+    expect(octokit.rest.git.createRef).toHaveBeenCalledTimes(3);
+    expect(octokit.rest.repos.merge).toHaveBeenCalledTimes(3);
+  });
+});
+
+describe("cleanupTestBranches", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("deletes test branches for closed PRs", async () => {
+    const octokit = makeOctokit({
+      git: {
+        listMatchingRefs: vi.fn().mockResolvedValue({
+          data: [
+            { ref: "refs/heads/merge-test/pr-1" },
+            { ref: "refs/heads/merge-test/pr-2" },
+            { ref: "refs/heads/merge-test/pr-3" },
+          ],
+        }),
+      },
+    });
+
+    // Only PRs 1 and 3 are still open
+    const openPrs = new Set([1, 3]);
+
+    const cleaned = await cleanupTestBranches(octokit, "owner", "repo", openPrs, "merge-test");
+
+    expect(cleaned).toBe(1);
+    expect(octokit.rest.git.deleteRef).toHaveBeenCalledWith({
+      owner: "owner",
+      repo: "repo",
+      ref: "heads/merge-test/pr-2",
+    });
+  });
+
+  it("does nothing when all test branches belong to open PRs", async () => {
+    const octokit = makeOctokit({
+      git: {
+        listMatchingRefs: vi.fn().mockResolvedValue({
+          data: [
+            { ref: "refs/heads/merge-test/pr-1" },
+          ],
+        }),
+      },
+    });
+
+    const cleaned = await cleanupTestBranches(octokit, "owner", "repo", new Set([1]), "merge-test");
+
+    expect(cleaned).toBe(0);
+    expect(octokit.rest.git.deleteRef).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `move-floating-tag.yml` workflow that runs on release publish
- Automatically moves the floating major version tag (e.g., `v1`) to point to the latest release
- Standard pattern used by `actions/checkout`, `actions/setup-python`, etc.

Closes #9