### PR TITLE
fix: next mode skips up-to-date PRs instead of stopping

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -34950,13 +34950,9 @@ async function updateBranches(octokit, owner, repo, prs, inputs) {
         const stateWasIndeterminate = mergeState === "UNKNOWN";
         // CLEAN: definitely up to date, skip
         if (mergeState === "CLEAN") {
-            core.info("Branch is up to date");
+            core.info("Branch is up to date, skipping");
             result.skipped++;
             core.endGroup();
-            if (inputs.updateMode === "next") {
-                core.info("Mode=next and top PR is current. Done.");
-                break;
-            }
             continue;
         }
         // DIRTY: has merge conflicts — label and notify, don't attempt update
@@ -34998,18 +34994,9 @@ async function updateBranches(octokit, owner, repo, prs, inputs) {
                 await handleConflict(octokit, owner, repo, pr.number, inputs);
                 break;
             case "up_to_date":
-                if (stateWasIndeterminate) {
-                    // GitHub may report "up to date" when mergeStateStatus was UNKNOWN
-                    // because it hasn't finished computing. Don't trust this result —
-                    // in next mode, continue to the next PR instead of bailing.
-                    core.info("Branch reported up to date, but merge state was UNKNOWN — result is unreliable");
-                    result.skipped++;
-                    definitive = false;
-                }
-                else {
-                    core.info("Branch is already up to date");
-                    result.skipped++;
-                }
+                core.info("Branch is already up to date");
+                result.skipped++;
+                definitive = false; // No work done — don't count as "processed" in next mode
                 break;
             case "sha_mismatch":
                 core.info("Branch changed during update (SHA mismatch). Will retry on next push.");

--- a/src/update-branches.ts
+++ b/src/update-branches.ts
@@ -228,14 +228,9 @@ export async function updateBranches(
 
     // CLEAN: definitely up to date, skip
     if (mergeState === "CLEAN") {
-      core.info("Branch is up to date");
+      core.info("Branch is up to date, skipping");
       result.skipped++;
       core.endGroup();
-
-      if (inputs.updateMode === "next") {
-        core.info("Mode=next and top PR is current. Done.");
-        break;
-      }
       continue;
     }
 
@@ -288,17 +283,9 @@ export async function updateBranches(
         await handleConflict(octokit, owner, repo, pr.number, inputs);
         break;
       case "up_to_date":
-        if (stateWasIndeterminate) {
-          // GitHub may report "up to date" when mergeStateStatus was UNKNOWN
-          // because it hasn't finished computing. Don't trust this result —
-          // in next mode, continue to the next PR instead of bailing.
-          core.info("Branch reported up to date, but merge state was UNKNOWN — result is unreliable");
-          result.skipped++;
-          definitive = false;
-        } else {
-          core.info("Branch is already up to date");
-          result.skipped++;
-        }
+        core.info("Branch is already up to date");
+        result.skipped++;
+        definitive = false; // No work done — don't count as "processed" in next mode
         break;
       case "sha_mismatch":
         core.info("Branch changed during update (SHA mismatch). Will retry on next push.");

--- a/tests/update-branches.test.ts
+++ b/tests/update-branches.test.ts
@@ -384,22 +384,100 @@ describe("updateBranches", () => {
     expect(octokit.rest.pulls.updateBranch).toHaveBeenCalledTimes(2);
   });
 
-  it("in next mode, stops after definitive up_to_date (non-UNKNOWN state)", async () => {
-    // First PR: BLOCKED state, updateBranch returns "up to date" — definitive
-    const octokit = makeOctokit(["blocked"]);
-    octokit.rest.pulls.updateBranch.mockRejectedValue({
-      status: 422,
-      message: "merge commit is already up to date",
-    });
+  it("in next mode, skips up_to_date PR (non-UNKNOWN state) and updates next behind PR", async () => {
+    // First PR: BLOCKED state, updateBranch returns "up to date" — no work done
+    // Second PR: BEHIND, updateBranch succeeds
+    let pullsGetCallCount = 0;
+    const octokit = {
+      rest: {
+        pulls: {
+          get: vi.fn().mockImplementation(({ pull_number }: { pull_number: number }) => {
+            pullsGetCallCount++;
+            if (pull_number === 1) {
+              return Promise.resolve({ data: { mergeable_state: "blocked" } });
+            }
+            return Promise.resolve({ data: { mergeable_state: "behind" } });
+          }),
+          updateBranch: vi.fn().mockImplementation(({ pull_number }: { pull_number: number }) => {
+            if (pull_number === 1) {
+              return Promise.reject({ status: 422, message: "merge commit is already up to date" });
+            }
+            return Promise.resolve({});
+          }),
+        },
+        issues: {
+          addLabels: vi.fn().mockResolvedValue({}),
+          createComment: vi.fn().mockResolvedValue({}),
+        },
+        actions: {
+          listWorkflowRuns: vi.fn().mockResolvedValue({ data: { workflow_runs: [] } }),
+          listWorkflowRunsForRepo: vi.fn().mockResolvedValue({ data: { workflow_runs: [] } }),
+          cancelWorkflowRun: vi.fn().mockResolvedValue({}),
+        },
+      },
+    } as any;
+
     const prs = [makePrioritizedPR(1, 0), makePrioritizedPR(2, 0)];
     const inputs = { ...defaultInputs, updateMode: "next" as const };
 
     const result = await updateBranches(octokit, "owner", "repo", prs, inputs);
 
+    // PR #1 skipped (up to date), PR #2 updated
     expect(result.skipped).toBe(1);
-    expect(result.updated).toBe(0);
-    // Should stop after first PR (definitive result)
+    expect(result.updated).toBe(1);
+    expect(octokit.rest.pulls.updateBranch).toHaveBeenCalledTimes(2);
+  });
+
+  it("in next mode, skips CLEAN PR and updates next behind PR", async () => {
+    // First PR: CLEAN (up to date), should be skipped
+    // Second PR: BEHIND, should be updated
+    let pullsGetCallCount = 0;
+    const octokit = {
+      rest: {
+        pulls: {
+          get: vi.fn().mockImplementation(({ pull_number }: { pull_number: number }) => {
+            pullsGetCallCount++;
+            if (pull_number === 1) {
+              return Promise.resolve({ data: { mergeable_state: "clean" } });
+            }
+            return Promise.resolve({ data: { mergeable_state: "behind" } });
+          }),
+          updateBranch: vi.fn().mockResolvedValue({}),
+        },
+        issues: {
+          addLabels: vi.fn().mockResolvedValue({}),
+          createComment: vi.fn().mockResolvedValue({}),
+        },
+        actions: {
+          listWorkflowRuns: vi.fn().mockResolvedValue({ data: { workflow_runs: [] } }),
+          listWorkflowRunsForRepo: vi.fn().mockResolvedValue({ data: { workflow_runs: [] } }),
+          cancelWorkflowRun: vi.fn().mockResolvedValue({}),
+        },
+      },
+    } as any;
+
+    const prs = [makePrioritizedPR(1, 0), makePrioritizedPR(2, 0)];
+    const inputs = { ...defaultInputs, updateMode: "next" as const };
+
+    const result = await updateBranches(octokit, "owner", "repo", prs, inputs);
+
+    // PR #1 skipped (CLEAN), PR #2 updated
+    expect(result.skipped).toBe(1);
+    expect(result.updated).toBe(1);
+    // updateBranch only called for PR #2 (CLEAN skips before API call)
     expect(octokit.rest.pulls.updateBranch).toHaveBeenCalledTimes(1);
+  });
+
+  it("in next mode, exits normally when all PRs are up to date", async () => {
+    const octokit = makeOctokit(["clean"]);
+    const prs = [makePrioritizedPR(1, 0), makePrioritizedPR(2, 0), makePrioritizedPR(3, 0)];
+    const inputs = { ...defaultInputs, updateMode: "next" as const };
+
+    const result = await updateBranches(octokit, "owner", "repo", prs, inputs);
+
+    expect(result.skipped).toBe(3);
+    expect(result.updated).toBe(0);
+    expect(octokit.rest.pulls.updateBranch).not.toHaveBeenCalled();
   });
 
   it("respects max-updates limit", async () => {


### PR DESCRIPTION
## Summary

- **Bug 1**: CLEAN merge state in `mode=next` broke out of the processing loop. Changed `break` to `continue` so up-to-date PRs are skipped and behind PRs still get updated.
- **Bug 2**: `up_to_date` API response with non-UNKNOWN merge state was treated as definitive ("we processed one PR, done"). Since no work was done, changed to non-definitive so the loop continues to the next PR.

## Test plan

- [x] Existing test updated: BLOCKED+up_to_date now expects continuation to the next PR
- [x] New test: CLEAN PR followed by BEHIND PR — verifies BEHIND PR gets updated
- [x] New test: all PRs CLEAN — verifies clean exit with all skipped
- [x] All 64 tests pass

Fixes #11