### PR TITLE
chore: upgrade from node20 to node24 runtime

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -92,5 +92,5 @@ outputs:
     value: ${{ steps.update.outputs.summary }}
 
 runs:
-  using: "node20"
+  using: "node24"
   main: "dist/index.js"

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
       },
       "devDependencies": {
         "@types/js-yaml": "^4.0.9",
-        "@types/node": "^20.17.0",
+        "@types/node": "^24.0.0",
         "@vercel/ncc": "^0.38.3",
         "typescript": "^5.7.0",
         "vitest": "^3.0.0"
@@ -1070,13 +1070,13 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "20.19.33",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.33.tgz",
-      "integrity": "sha512-Rs1bVAIdBs5gbTIKza/tgpMuG1k3U/UMJLWecIMxNdJFDMzcM5LOiLVRYh3PilWEYDIeUDv7bpiHPLPsbydGcw==",
+      "version": "24.12.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.12.2.tgz",
+      "integrity": "sha512-A1sre26ke7HDIuY/M23nd9gfB+nrmhtYyMINbjI1zHJxYteKR6qSMX56FsmjMcDb3SMcjJg5BiRRgOCC/yBD0g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~6.21.0"
+        "undici-types": "~7.16.0"
       }
     },
     "node_modules/@vercel/ncc": {
@@ -1722,9 +1722,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
-      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
+      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "devDependencies": {
     "@types/js-yaml": "^4.0.9",
-    "@types/node": "^20.17.0",
+    "@types/node": "^24.0.0",
     "@vercel/ncc": "^0.38.3",
     "typescript": "^5.7.0",
     "vitest": "^3.0.0"


### PR DESCRIPTION
## Summary
- Update `action.yml` runtime from `node20` to `node24`
- Bump `@types/node` from `^20.17.0` to `^24.0.0`
- Rebuild dist bundle

GitHub Actions is deprecating node20 runners (default switches to node24 March 2026).

Closes #13